### PR TITLE
Clean up socket IO and socket connect API

### DIFF
--- a/echoes.c
+++ b/echoes.c
@@ -95,18 +95,14 @@ read_done_cb(int64_t tfd, void *buf, ssize_t result, void *user_data)
 	e->received += result;
 
 	// Now just write it straight back!
-	result = TASK_socket_write(e->tfd, e->buffer, result, TASK_TIMEOUT_ONE_SEC * 15, e, write_done_cb);
-	write_done_cb(e->tfd, e->buffer, result, e);
+	TASK_socket_write(e->tfd, e->buffer, result, TASK_TIMEOUT_ONE_SEC * 15, e, write_done_cb);
 } // read_done_cb
 
 
 static void
 start_read(struct echo *e)
 {
-	ssize_t result;
-
-	result = TASK_socket_read(e->tfd, e->buffer, BUFLEN, TASK_TIMEOUT_ONE_SEC * 30, e, read_done_cb);
-	read_done_cb(e->tfd, e->buffer, result, e);
+	TASK_socket_read(e->tfd, e->buffer, BUFLEN, TASK_TIMEOUT_ONE_SEC * 30, e, read_done_cb);
 } // start_read
 
 

--- a/load_gen.c
+++ b/load_gen.c
@@ -100,11 +100,8 @@ loadgen_read_cb(int64_t tfd, void *buf, ssize_t result, void *user_data)
 static void
 loadgen_start_rd(struct loadgen *lg)
 {
-	ssize_t result;
-
 	lg->num_rd_calls++;
-	result = TASK_socket_read(lg->tfd, lg->rd_buf, BUFLEN, TASK_TIMEOUT_ONE_SEC * 15, lg, loadgen_read_cb);
-	loadgen_read_cb(lg->tfd, lg->rd_buf, result, lg);
+	TASK_socket_read(lg->tfd, lg->rd_buf, BUFLEN, TASK_TIMEOUT_ONE_SEC * 15, lg, loadgen_read_cb);
 } // loadgen_start_rd
 
 
@@ -148,7 +145,6 @@ loadgen_write_cb(int64_t tfd, const void *buf, ssize_t result, void *user_data)
 static void
 loadgen_start_wr(struct loadgen *lg)
 {
-	ssize_t result;
 	size_t wr_size = 0;
 
 	wr_size = deliver_size - lg->delivered;
@@ -160,8 +156,7 @@ loadgen_start_wr(struct loadgen *lg)
 	}
 
 	lg->num_wr_calls++;
-	result = TASK_socket_write(lg->tfd, lg->wr_buf, wr_size, TASK_TIMEOUT_ONE_SEC * 15, lg, loadgen_write_cb);
-	loadgen_write_cb(lg->tfd, lg->wr_buf, result, lg);
+	TASK_socket_write(lg->tfd, lg->wr_buf, wr_size, TASK_TIMEOUT_ONE_SEC * 15, lg, loadgen_write_cb);
 } // loadgen_start_wr
 
 
@@ -190,7 +185,6 @@ static void
 loadgen_connect(struct loadgen *lg)
 {
 	struct sockaddr_in lca;
-	int res;
 
 	lca.sin_family = AF_INET;
 	lca.sin_addr.s_addr = INADDR_ANY;
@@ -213,8 +207,7 @@ loadgen_connect(struct loadgen *lg)
 		return;
 	}
 
-	res = TASK_socket_connect(lg->tfd, (struct sockaddr *)lg->addr, sizeof(struct sockaddr_in), TASK_TIMEOUT_ONE_SEC * 15, (void *)lg, connect_complete_cb);
-	connect_complete_cb(lg->tfd, res, lg);
+	TASK_socket_connect(lg->tfd, (struct sockaddr *)lg->addr, sizeof(struct sockaddr_in), TASK_TIMEOUT_ONE_SEC * 15, (void *)lg, connect_complete_cb);
 }
 
 

--- a/task_lib.h
+++ b/task_lib.h
@@ -91,22 +91,29 @@ int64_t TASK_timeout_create(int32_t ti, int64_t expires_in_us, void *user_data,
 //-------------------------------------------------------------------------------------------
 
 // Will write the entire contents of the supplied buffers to the given tfd, or expire trying
-ssize_t TASK_socket_writev(int64_t tfd, const struct iovec *iov, int iovcnt, int64_t expires_in_us, void *user_data,
+void TASK_socket_writev(int64_t tfd, const struct iovec *iov, int iovcnt, int64_t expires_in_us, void *user_data,
 			  void (*wrv_cb)(int64_t tfd, const struct iovec *iov, int iovcnt, ssize_t result, void *user_data));
 
 // Will write the entire contents of the supplied buffer to the given tfd, or expire trying
-ssize_t TASK_socket_write(int64_t tfd, const void *buf, size_t buflen, int64_t expires_in_us, void *user_data,
+void TASK_socket_write(int64_t tfd, const void *buf, size_t buflen, int64_t expires_in_us, void *user_data,
 			 void (*write_cb)(int64_t tfd, const void *buf, ssize_t result, void *user_data));
 
-ssize_t TASK_socket_readv(int64_t tfd, const struct iovec *iov, int iovcnt, int64_t expires_in_us, void *user_data,
+void TASK_socket_readv(int64_t tfd, const struct iovec *iov, int iovcnt, int64_t expires_in_us, void *user_data,
 			 void (*readv_cb)(int64_t tfd, const struct iovec *iov, int iovcnt, ssize_t result, void *user_data));
 
-ssize_t TASK_socket_read(int64_t tfd, void *buf, size_t buflen, int64_t expires_in_us, void *user_data,
+void TASK_socket_read(int64_t tfd, void *buf, size_t buflen, int64_t expires_in_us, void *user_data,
 			void (*read_cb)(int64_t tfd, void *buf, ssize_t result, void *user_data));
+
+// Connect to given destination address. If src_addr is NULL, it will just use the default interface IP and choose any local source port
+void TASK_socket_connect(int64_t tfd, struct sockaddr *addr, socklen_t addrlen, int64_t expires_in_us,
+		       void *user_data, void (*connect_cb)(int64_t tfd, int result, void *user_data));
 
 //-------------------------------------------------------------------------------------------
 // Task Library Socket API
 //-------------------------------------------------------------------------------------------
+
+// Listen for and accept new connections on a given addr
+int TASK_socket_listen(int64_t tfd, void *user_data, void (*accept_cb)(int64_t tfd, void *user_data));
 
 // Returns the direct UNIX socket that the tfd is operating on
 int TASK_socket_get_fd(int64_t tfd);
@@ -121,13 +128,6 @@ int TASK_migrate(int64_t to_tfd, int64_t from_tfd);
 // If called against a timeout-only task, it just calls TASK_timeout_destroy(tfd);
 int TASK_close(int64_t tfd);
 int TASK_socket_shutdown(int64_t tfd, int how);
-
-// Listen for and accept new connections on a given addr
-int TASK_socket_listen(int64_t tfd, void *user_data, void (*accept_cb)(int64_t tfd, void *user_data));
-
-// Connect to given destination address. If src_addr is NULL, it will just use the default interface IP and choose any local source port
-int TASK_socket_connect(int64_t tfd, struct sockaddr *addr, socklen_t addrlen, int64_t expires_in_us,
-		       void *user_data, void (*connect_cb)(int64_t tfd, int result, void *user_data));
 
 int TASK_socket_bind(int64_t tfd, struct sockaddr *addr, socklen_t addrlen);
 


### PR DESCRIPTION
The Tasklib socket read/write buffer and vectored IO calls have been changed to return a NULL type, as has `TASK_socket_connect()`. 

In all instances the calls will now return their results to the callback, removing the need for the caller to make the callback themselves in certain circumstances.

This cleans up the API usage dramatically.

As always, care must be taken in this instance.  It is best practise for the caller to return control back to Tasklib immediately after making a socket IO call, as the callback may, or may not, have already been called by the time the IO call returns.  It is always best to let the callback drive the next step on what to do with the connection, and not from the caller.